### PR TITLE
Fixed issue where character names above "Collectibles" disappeared

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -302,9 +302,7 @@ $("document").ready(function () {
         } else if (thumbnailsHidden === true) {
             $("#get-info-bottom").show();
             $(".hideOnUp").css("display", "none");
-            $("#ebayResults").empty();
-            $("#ebayResultsLeft").empty();
-            $("#ebayResultsRight").empty();
+            $(".ebayRow").remove();
             $("#get-info").text("TEAM UP!");
             $("#searchInput").show();
             $(".searchMessage").show();


### PR DESCRIPTION
Rather than emptying out the ebayResults divs, new code just removes any element with the ebayRow class.